### PR TITLE
fix prod http loading issue

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -115,8 +115,10 @@
     </body>
     <script>
         $(document).ready(function() {
+            var str = "{{ request()->getSchemeAndHttpHost() }}/posts";
+            var res = str.replace("http", "https");
             $('#example').DataTable( {
-                "ajax": {"url":"{{ request()->getSchemeAndHttpHost() }}/posts","dataSrc":""},
+                "ajax": {"url":res,"dataSrc":""},
                 "columns": [
                     {
                         "render": function ( data, type, row ) {


### PR DESCRIPTION
laravel getSchemeAndHttpHost doesn't return if we are arriving via https or not under heroku despite this being part of the Laravel functionality.
Dirty .js hack to fix.